### PR TITLE
-I and -L flags

### DIFF
--- a/configure
+++ b/configure
@@ -64,7 +64,7 @@ EOF
 exit 0;
 fi
 
-mkdir -pv "${build_dir}";
+mkdir -p "${build_dir}";
 build_dir="$(realpath "${build_dir}")";
 
 tmp_dir="${build_dir}/.tmp";
@@ -73,7 +73,7 @@ tmp_c="${tmp_dir}/tmp.c";
 tmp_cpp="${tmp_dir}/tmp.cpp";
 tmp_exe="${tmp_dir}/tmp.exe";
 
-mkdir -pv "${tmp_dir}";
+mkdir -p "${tmp_dir}";
 rm -f "${build_dir}/config.log";
 
 config_make="${build_dir}/config.make";

--- a/configure
+++ b/configure
@@ -100,9 +100,9 @@ print_config()
 }
 
 # Default flags.
-CFLAGS="-O2 -D_GNU_SOURCE -include ${build_dir}/config.h";
-CXXFLAGS="-O2 -D_GNU_SOURCE -include ${build_dir}/config.h";
-LDFLAGS="-O2";
+CFLAGS="-I/usr/include -I/usr/local/include -O2 -D_GNU_SOURCE -include ${build_dir}/config.h";
+CXXFLAGS="-I/usr/include -I/usr/local/include -O2 -D_GNU_SOURCE -include ${build_dir}/config.h";
+LDFLAGS="-L/usr/lib -L/usr/local/lib -O2";
 LIB_LDFLAGS="-lpthread -ljson-c -lcurl";
 
 # Print configure header at the top of $config_h.


### PR DESCRIPTION
In certain platform like OpenBSD, Path to header files & libraries did not point to /usr/local by default.